### PR TITLE
Jetpack Compose移行 Phase 1: 基盤セットアップと共通コンポーネント実装

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(find:*)",
+      "Bash(git add:*)"
+    ],
+    "deny": []
+  }
+}

--- a/feature/corecomponent/build.gradle.kts
+++ b/feature/corecomponent/build.gradle.kts
@@ -14,6 +14,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.compose.compiler)
     alias(libs.plugins.ksp)
     alias(libs.plugins.kapt)
     alias(libs.plugins.navigation.safeargs)
@@ -49,6 +50,7 @@ android {
     }
     buildFeatures {
         dataBinding = true
+        compose = true
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
@@ -85,11 +87,24 @@ dependencies {
 
     api(libs.glide)
     ksp(libs.glide.compiler)
+    api(libs.glide.compose)
 
     api(libs.rxjava)
     api(libs.rxandroid)
 
     api(libs.timber)
+
+    // Jetpack Compose
+    val composeBom = platform(libs.androidx.compose.bom)
+    api(composeBom)
+    api(libs.androidx.compose.ui)
+    api(libs.androidx.compose.ui.graphics)
+    api(libs.androidx.compose.ui.tooling.preview)
+    api(libs.androidx.compose.material3)
+    api(libs.androidx.activity.compose)
+    api(libs.androidx.lifecycle.viewmodel.compose)
+    debugImplementation(libs.androidx.compose.ui.tooling)
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
 
     implementation(libs.dagger)
     ksp(libs.dagger.compiler)

--- a/feature/corecomponent/src/main/java/me/rei_m/hyakuninisshu/feature/corecomponent/compose/component/DropdownSelector.kt
+++ b/feature/corecomponent/src/main/java/me/rei_m/hyakuninisshu/feature/corecomponent/compose/component/DropdownSelector.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2025. Rei Matsushita
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package me.rei_m.hyakuninisshu.feature.corecomponent.compose.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import me.rei_m.hyakuninisshu.feature.corecomponent.compose.theme.HyakuninisshuTheme
+import me.rei_m.hyakuninisshu.feature.corecomponent.compose.theme.WhiteSmoke
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun <T> DropdownSelector(
+    items: List<T>,
+    selectedItem: T?,
+    onItemSelected: (T) -> Unit,
+    modifier: Modifier = Modifier,
+    label: String = "",
+    itemContent: @Composable (T) -> String = { it.toString() }
+) {
+    var expanded by remember { mutableStateOf(false) }
+    
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded },
+        modifier = modifier
+    ) {
+        TextField(
+            value = selectedItem?.let { itemContent(it) } ?: "",
+            onValueChange = {},
+            modifier = Modifier
+                .menuAnchor()
+                .fillMaxWidth()
+                .background(WhiteSmoke),
+            readOnly = true,
+            label = { Text(label) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            colors = ExposedDropdownMenuDefaults.textFieldColors(
+                containerColor = WhiteSmoke
+            )
+        )
+        
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = Modifier.background(MaterialTheme.colorScheme.surface)
+        ) {
+            items.forEach { item ->
+                DropdownMenuItem(
+                    text = { Text(itemContent(item)) },
+                    onClick = {
+                        onItemSelected(item)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DropdownSelectorPreview() {
+    HyakuninisshuTheme {
+        val items = listOf("Item 1", "Item 2", "Item 3")
+        var selectedItem by remember { mutableStateOf(items[0]) }
+        
+        DropdownSelector(
+            items = items,
+            selectedItem = selectedItem,
+            onItemSelected = { selectedItem = it },
+            label = "Select an item"
+        )
+    }
+}

--- a/feature/corecomponent/src/main/java/me/rei_m/hyakuninisshu/feature/corecomponent/compose/component/HyakuninisshuAppBar.kt
+++ b/feature/corecomponent/src/main/java/me/rei_m/hyakuninisshu/feature/corecomponent/compose/component/HyakuninisshuAppBar.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025. Rei Matsushita
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package me.rei_m.hyakuninisshu.feature.corecomponent.compose.component
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import me.rei_m.hyakuninisshu.feature.corecomponent.compose.theme.HyakuninisshuTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HyakuninisshuAppBar(
+    title: String,
+    modifier: Modifier = Modifier,
+    onNavigationClick: (() -> Unit)? = null,
+    actions: @Composable () -> Unit = {}
+) {
+    TopAppBar(
+        title = { Text(title) },
+        modifier = modifier,
+        navigationIcon = {
+            if (onNavigationClick != null) {
+                IconButton(onClick = onNavigationClick) {
+                    Icon(
+                        imageVector = Icons.Default.ArrowBack,
+                        contentDescription = "Navigate back"
+                    )
+                }
+            }
+        },
+        actions = { actions() },
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = MaterialTheme.colorScheme.primary,
+            titleContentColor = MaterialTheme.colorScheme.onPrimary,
+            navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
+            actionIconContentColor = MaterialTheme.colorScheme.onPrimary
+        )
+    )
+}
+
+@Preview
+@Composable
+fun HyakuninisshuAppBarPreview() {
+    HyakuninisshuTheme {
+        HyakuninisshuAppBar(
+            title = "百人一首",
+            onNavigationClick = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+fun HyakuninisshuAppBarNoBackPreview() {
+    HyakuninisshuTheme {
+        HyakuninisshuAppBar(
+            title = "百人一首"
+        )
+    }
+}

--- a/feature/corecomponent/src/main/java/me/rei_m/hyakuninisshu/feature/corecomponent/compose/component/HyakuninisshuButton.kt
+++ b/feature/corecomponent/src/main/java/me/rei_m/hyakuninisshu/feature/corecomponent/compose/component/HyakuninisshuButton.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025. Rei Matsushita
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package me.rei_m.hyakuninisshu.feature.corecomponent.compose.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import me.rei_m.hyakuninisshu.feature.corecomponent.compose.theme.HyakuninisshuTheme
+
+@Composable
+fun HyakuninisshuButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(48.dp),
+        enabled = enabled,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.secondary,
+            contentColor = MaterialTheme.colorScheme.onSecondary
+        )
+    ) {
+        Text(text = text)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun HyakuninisshuButtonPreview() {
+    HyakuninisshuTheme {
+        HyakuninisshuButton(
+            text = "開始",
+            onClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun HyakuninisshuButtonDisabledPreview() {
+    HyakuninisshuTheme {
+        HyakuninisshuButton(
+            text = "開始",
+            onClick = {},
+            enabled = false
+        )
+    }
+}

--- a/feature/corecomponent/src/main/java/me/rei_m/hyakuninisshu/feature/corecomponent/compose/component/KarutaImage.kt
+++ b/feature/corecomponent/src/main/java/me/rei_m/hyakuninisshu/feature/corecomponent/compose/component/KarutaImage.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025. Rei Matsushita
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package me.rei_m.hyakuninisshu.feature.corecomponent.compose.component
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
+import com.bumptech.glide.integration.compose.GlideImage
+import com.bumptech.glide.integration.compose.placeholder
+import me.rei_m.hyakuninisshu.feature.corecomponent.R
+import me.rei_m.hyakuninisshu.feature.corecomponent.compose.theme.HyakuninisshuTheme
+
+@OptIn(ExperimentalGlideComposeApi::class)
+@Composable
+fun KarutaImage(
+    @DrawableRes resId: Int,
+    contentDescription: String?,
+    modifier: Modifier = Modifier
+) {
+    GlideImage(
+        model = resId,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        contentScale = ContentScale.Fit,
+        loading = placeholder(R.drawable.tatami_part)
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun KarutaImagePreview() {
+    HyakuninisshuTheme {
+        KarutaImage(
+            resId = R.drawable.tatami_part,
+            contentDescription = "Karuta card",
+            modifier = Modifier.fillMaxSize()
+        )
+    }
+}

--- a/feature/corecomponent/src/main/java/me/rei_m/hyakuninisshu/feature/corecomponent/compose/component/TatamiBackground.kt
+++ b/feature/corecomponent/src/main/java/me/rei_m/hyakuninisshu/feature/corecomponent/compose/component/TatamiBackground.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025. Rei Matsushita
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package me.rei_m.hyakuninisshu.feature.corecomponent.compose.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import me.rei_m.hyakuninisshu.feature.corecomponent.R
+import me.rei_m.hyakuninisshu.feature.corecomponent.compose.theme.HyakuninisshuTheme
+
+@Composable
+fun TatamiBackground(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.White)
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.tatami),
+            contentDescription = null,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.FillBounds
+        )
+        content()
+    }
+}
+
+@Preview
+@Composable
+fun TatamiBackgroundPreview() {
+    HyakuninisshuTheme {
+        TatamiBackground {
+            // Content goes here
+        }
+    }
+}

--- a/feature/corecomponent/src/main/java/me/rei_m/hyakuninisshu/feature/corecomponent/compose/component/VerticalText.kt
+++ b/feature/corecomponent/src/main/java/me/rei_m/hyakuninisshu/feature/corecomponent/compose/component/VerticalText.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025. Rei Matsushita
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package me.rei_m.hyakuninisshu.feature.corecomponent.compose.component
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import me.rei_m.hyakuninisshu.feature.corecomponent.compose.theme.Blackba
+import me.rei_m.hyakuninisshu.feature.corecomponent.compose.theme.HannariFontFamily
+import me.rei_m.hyakuninisshu.feature.corecomponent.compose.theme.HyakuninisshuTheme
+
+@Composable
+fun VerticalText(
+    text: String,
+    modifier: Modifier = Modifier,
+    fontSize: TextUnit = 16.sp,
+    fontFamily: FontFamily = HannariFontFamily,
+    style: TextStyle = TextStyle.Default
+) {
+    val density = LocalDensity.current
+    val textPaint = android.graphics.Paint().apply {
+        isAntiAlias = true
+        textSize = with(density) { fontSize.toPx() }
+        color = style.color.hashCode()
+        typeface = android.graphics.Typeface.DEFAULT
+    }
+    
+    val textSizeDp: Dp = with(density) { fontSize.toDp() }
+    val height: Dp = textSizeDp * text.length * 1.05f
+    
+    Canvas(
+        modifier = modifier.size(width = textSizeDp, height = height)
+    ) {
+        drawIntoCanvas { canvas ->
+            text.forEachIndexed { index, char ->
+                canvas.nativeCanvas.drawText(
+                    char.toString(),
+                    0f,
+                    textPaint.textSize * (index + 1),
+                    textPaint
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun VerticalTextPreview() {
+    HyakuninisshuTheme {
+        VerticalText(
+            text = "百人一首",
+            fontSize = 24.sp,
+            style = TextStyle(color = Blackba)
+        )
+    }
+}

--- a/feature/corecomponent/src/main/java/me/rei_m/hyakuninisshu/feature/corecomponent/compose/theme/Color.kt
+++ b/feature/corecomponent/src/main/java/me/rei_m/hyakuninisshu/feature/corecomponent/compose/theme/Color.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025. Rei Matsushita
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package me.rei_m.hyakuninisshu.feature.corecomponent.compose.theme
+
+import androidx.compose.ui.graphics.Color
+
+val ColorPrimary = Color(0xFF8BC34A)
+val ColorPrimaryDark = Color(0xFF689F38)
+val ColorSecondary = Color(0xFFFF9100)
+val ColorAccent = Color(0xFFFF9100)
+val ColorAccent66 = Color(0x66FF9100)
+val Black10 = Color(0x10000000)
+val Black22 = Color(0x22000000)
+val Black33 = Color(0x33000000)
+val Black8a = Color(0x8a000000)
+val Blackba = Color(0xba000000)
+val White66 = Color(0x66ffffff)
+val White99 = Color(0x99ffffff)
+val WhiteSmoke = Color(0xfff5f5f5)
+val WhitePaper = Color(0xfffffff0)
+val Fuda = Color(0xff556b2f)

--- a/feature/corecomponent/src/main/java/me/rei_m/hyakuninisshu/feature/corecomponent/compose/theme/Theme.kt
+++ b/feature/corecomponent/src/main/java/me/rei_m/hyakuninisshu/feature/corecomponent/compose/theme/Theme.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025. Rei Matsushita
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package me.rei_m.hyakuninisshu.feature.corecomponent.compose.theme
+
+import android.app.Activity
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
+
+private val DarkColorScheme = darkColorScheme(
+    primary = ColorPrimary,
+    secondary = ColorSecondary,
+    tertiary = ColorAccent
+)
+
+private val LightColorScheme = lightColorScheme(
+    primary = ColorPrimary,
+    secondary = ColorSecondary,
+    tertiary = ColorAccent,
+    background = WhiteSmoke,
+    surface = WhitePaper,
+    onPrimary = WhiteSmoke,
+)
+
+@Composable
+fun HyakuninisshuTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    dynamicColor: Boolean = false,
+    content: @Composable () -> Unit
+) {
+    val colorScheme = when {
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            val context = LocalContext.current
+            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        }
+
+        darkTheme -> DarkColorScheme
+        else -> LightColorScheme
+    }
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            window.statusBarColor = colorScheme.primary.toArgb()
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
+        }
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = AppTypography,
+        content = content
+    )
+}

--- a/feature/corecomponent/src/main/java/me/rei_m/hyakuninisshu/feature/corecomponent/compose/theme/Typography.kt
+++ b/feature/corecomponent/src/main/java/me/rei_m/hyakuninisshu/feature/corecomponent/compose/theme/Typography.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025. Rei Matsushita
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package me.rei_m.hyakuninisshu.feature.corecomponent.compose.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import me.rei_m.hyakuninisshu.feature.corecomponent.R
+
+val HannariFontFamily = FontFamily(
+    Font(R.font.hannari)
+)
+
+val AppTypography = Typography(
+    bodyLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.5.sp
+    ),
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 22.sp,
+        lineHeight = 28.sp,
+        letterSpacing = 0.sp
+    ),
+    labelSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 11.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.5.sp
+    )
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,9 @@ ksp = "2.2.0-2.0.2"
 leakcanary = "2.14"
 androidRate = "1.0.1"
 ktlint = "13.0.0"
+composeBom = "2024.10.01"
+activityCompose = "1.10.1"
+lifecycleViewmodelCompose = "2.9.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -74,11 +77,24 @@ rxjava = { group = "io.reactivex.rxjava2", name = "rxjava", version.ref = "rxJav
 rxandroid = { group = "io.reactivex.rxjava2", name = "rxandroid", version.ref = "rxAndroid" }
 glide = { group = "com.github.bumptech.glide", name = "glide", version.ref = "glide" }
 glide-compiler = { group = "com.github.bumptech.glide", name = "ksp", version.ref = "glide" }
+glide-compose = { group = "com.github.bumptech.glide", name = "compose", version = "1.0.0-beta01" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics", version.ref = "firebaseCrashlytics" }
 firebase-ads = { group = "com.google.firebase", name = "firebase-ads", version.ref = "firebaseAds" }
 android-oss-licenses = { group = "com.google.android.gms", name = "play-services-oss-licenses", version.ref = "ossLicenses" }
 leakcanary = { group = "com.squareup.leakcanary", name = "leakcanary-android", version.ref = "leakcanary" }
 rate = { group = "com.github.hotchemi", name = "android-rate", version.ref = "androidRate" }
+
+# Jetpack Compose
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
+androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
 
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTesttJunit" }
@@ -118,3 +134,4 @@ ksp-top = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 ksp = { id = "com.google.devtools.ksp" }
 kapt = { id = "kotlin-kapt" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary
- Jetpack Compose導入のための基盤セットアップを実施
- corecomponentモジュールに共通Composeコンポーネントとテーマシステムを実装
- 既存のUIコンポーネントをComposeで再実装（Phase 1）

## 実装内容

### 依存関係の追加
- `gradle/libs.versions.toml`にJetpack Compose関連の依存関係を追加
- `feature/corecomponent/build.gradle.kts`にCompose設定を追加

### 共通コンポーネントの実装
- **KarutaImage**: かるた画像表示用のComposeコンポーネント（Glide統合）
- **HyakuninisshuAppBar**: アプリ共通のトップアプリバー
- **HyakuninisshuButton**: カスタムボタンコンポーネント
- **DropdownSelector**: ドロップダウン選択UI
- **VerticalText**: 縦書きテキスト表示コンポーネント
- **TatamiBackground**: 畳柄の背景コンポーネント

### テーマシステムの構築
- カラーパレットの定義（既存のアプリカラーをComposeに移植）
- タイポグラフィの設定
- マテリアル3ベースのテーマ実装

## Test plan
- [ ] プロジェクトが正常にビルドされることを確認
- [ ] 既存の機能に影響がないことを確認
- [ ] Composeのプレビュー機能が正常に動作することを確認

## 関連イシュー
Closes #187

🤖 Generated with [Claude Code](https://claude.ai/code)